### PR TITLE
VIVI-11375 Allowing adding a CNAME to @ and www

### DIFF
--- a/bin/xip-pdns
+++ b/bin/xip-pdns
@@ -75,13 +75,14 @@ qtype_is() {
   [ "$QTYPE" = "$1" ] || [ "$QTYPE" = "ANY" ]
 }
 
-qname_is_root_domain() {
-  [ "$QNAME" = "$ROOT_DOMAIN" ]
+qname_is_rootish() {
+  [[ "$QNAME" =~ $ROOTISH_DOMAIN_PATTERN ]]
 }
 
 extract_root_domain_from_qname()
 {
   ROOT_DOMAIN=$(echo "${QNAME}" | sed 's/^.*\.\(.*\..*\)/\1/')
+  ROOTISH_DOMAIN_PATTERN="^(www\.)?${ROOT_DOMAIN}\$"
 }
 
 extract_subdomain_from_qname() {
@@ -137,6 +138,12 @@ answer_root_a_query() {
   done
 }
 
+answer_rootish_any_query() {
+  if [ -n "$ROOTISH_CNAME_ADDRESS" ]; then
+    send_answer "CNAME" "$ROOTISH_CNAME_ADDRESS"
+  fi
+}
+
 answer_subdomain_a_query_for() {
   local type="$1"
   local address="$(resolve_${type}_subdomain)"
@@ -162,8 +169,10 @@ while read_query; do
 
   extract_root_domain_from_qname
 
-  if qname_is_root_domain; then
-    if qtype_is "SOA"; then
+  if qname_is_rootish; then
+    if qtype_is "ANY"; then
+      answer_rootish_any_query
+    elif qtype_is "SOA"; then
       answer_soa_query
     elif qtype_is "NS"; then
       answer_ns_query

--- a/etc/xip-pdns.conf.example
+++ b/etc/xip-pdns.conf.example
@@ -14,6 +14,8 @@ XIP_NS_ADDRESSES=( "1.2.3.4" "1.2.3.5" )
 # How long responses should be cached, in seconds.
 XIP_TTL=300
 
+ROOTISH_CNAME_ADDRESS=""
+
 # key = entire domain, value = TXT record data
 # e.g. TXT_RECORDS["mysubdomain.example.com"]="aGVsbG8gZnJvbSB2aXZpIQ"
 declare -A TXT_RECORDS


### PR DESCRIPTION
Ian wants @ and www to just redirect to our website, so the idea is we'll set `ROOTISH_CNAME_ADDRESS` to a CloudFront URL that has a Lambda@Edge function that does the redirect.

You can see this partially working on vivi-box-staging.io, I am not able to get past the 403 without an SSL cert (which on AWS requires a CNAME instead of a TXT to validate, but you can also just upload an existing one which I'll do for vivi-box.io proper), but that obviously has nothing to do with this service